### PR TITLE
chore: Bump jq version to 1.7 (#33)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: 'Setup jq'
       uses: dcarbone/install-jq-action@v2.1.0
       with:
-        version: 1.6
+        version: 1.7
         force: 'true'
 
     - uses: actions/download-artifact@v4


### PR DESCRIPTION
## what
* Bump jq version from `1.6` to `1.7`

## why
* jq version 1.7 was released over a year ago
* force installing 1.6 is interfering with some local / self-hosted GH action runners. 

## references
* closes #33
