### PR TITLE
Update dependencies for Node 24 and artifact v7 compatibility

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,12 @@ runs:
   using: "composite"
   steps:
     - name: 'Setup jq'
-      uses: dcarbone/install-jq-action@v2.1.0
+      uses: dcarbone/install-jq-action@v3.0.0
       with:
-        version: 1.6
+        version: 1.7
         force: 'true'
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v7
 
     - id: context
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Matrix outputs - read'
+name: 'Matrix outputs - read node24'
 description: 'Read outputs for matrix'
 author: hello@cloudposse.com
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'Matrix outputs - read node24'
+name: 'Matrix outputs - read'
 description: 'Read outputs for matrix'
 author: hello@cloudposse.com
 branding:


### PR DESCRIPTION
  ## what                                                                                                                                                                                                 
  - Bump `actions/download-artifact` from `v4` to `v7`            
  - Bump `dcarbone/install-jq-action` from `v2.1.0` to `v3.0.0`
  - Bump jq from `1.6` to `1.7`                                                                                                                                                                           
   
  ## why                                                                                                                                                                                                  
  - GitHub is deprecating Node.js 20 for Actions runners. Node 24 becomes the default on June 2, 2026 and Node 20 is removed entirely on September 16, 2026.
  - `actions/download-artifact@v4` cannot download artifacts uploaded by `actions/upload-artifact@v7` or by other actions using `@actions/artifact` SDK v2.3+, causing "Artifact download failed after 5  
  retries" errors. Bumping to `v7` restores compatibility.                                                                                                                                                
  - `dcarbone/install-jq-action@v2.1.0` uses deprecated `Buffer()` constructor, producing `[DEP0005] DeprecationWarning` under Node 24 runners. v3.0.0 resolves this.                                     
                                                                                                                                                                                                          
  ## references                                                   
  - https://github.com/cloudposse/github-action-matrix-outputs-write/issues/69                                                                                                                            
 - [GitHub announcement: Actions Node.js 20 deprecation](https://github.blog/changelog/2025-05-05-github-actions-deprecating-node20-and-adding-node24-support/)                                          

## Testing

I tested this version in our production workflow here :
* read https://github.com/NVIDIA/cuda-quantum/actions/runs/24042143620/job/70116907516?pr=4254
* write https://github.com/NVIDIA/cuda-quantum/actions/runs/24042143620/job/70117236576?pr=4254#step:2:16