### PR TITLE
chore: upgrade actions to Node 24 runtime (SHA-pinned)

### DIFF
--- a/.github/workflows/setup-test.yml
+++ b/.github/workflows/setup-test.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "Do setup"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: cloudposse/github-action-matrix-outputs-write@v1
         id: writer

--- a/.github/workflows/test-negative.yml
+++ b/.github/workflows/test-negative.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "Do setup"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: cloudposse/github-action-matrix-outputs-write@v1
         with:
@@ -39,7 +39,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{}'
           actual: "${{ needs.test.outputs.result }}"

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo "Do setup"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: cloudposse/github-action-matrix-outputs-write@v1
         with:
@@ -41,7 +41,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -55,12 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'one'
           actual: ${{ fromJson(needs.test.outputs.result).result.one }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'two'
           actual: ${{ fromJson(needs.test.outputs.result).result.two }}

--- a/.github/workflows/test-reusable-workflow-no-matrix.yml
+++ b/.github/workflows/test-reusable-workflow-no-matrix.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     outputs:
       result: "${{ needs.setup.outputs.result }}"
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: '{"result":"one"}'
           actual: "${{ needs.test.outputs.result }}"
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'one'
           actual: ${{ fromJson(needs.test.outputs.result).result }}

--- a/.github/workflows/test-reusable-workflow-twice.yml
+++ b/.github/workflows/test-reusable-workflow-twice.yml
@@ -42,7 +42,7 @@ jobs:
     needs: [setup, setup2]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current1
@@ -63,22 +63,22 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'one'
           actual: ${{ fromJson(needs.test.outputs.result1).result.one }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'two'
           actual: ${{ fromJson(needs.test.outputs.result1).result.two }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'three'
           actual: ${{ fromJson(needs.test.outputs.result2).result.three }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'four'
           actual: ${{ fromJson(needs.test.outputs.result2).result.four }}

--- a/.github/workflows/test-reusable-workflow.yml
+++ b/.github/workflows/test-reusable-workflow.yml
@@ -32,7 +32,7 @@ jobs:
     needs: [setup]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./
         id: current
@@ -46,12 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'one'
           actual: ${{ fromJson(needs.test.outputs.result).result.one }}
 
-      - uses: nick-fields/assert-action@v2
+      - uses: nick-fields/assert-action@0efd6166067d9c59d89c710fab4f79fb066f8985 # v4.0.1
         with:
           expected: 'two'
           actual: ${{ fromJson(needs.test.outputs.result).result.two }}

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
         version: 1.6
         force: 'true'
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 
     - id: context
       shell: bash


### PR DESCRIPTION
## what

* Bump GitHub Actions references in the workflows to versions running on the Node 24 runtime,
  SHA-pinned with precise version comments:
  * `actions/checkout@v4` → `@3d3c42e5...` `# v7.0.1`
  * `actions/download-artifact@v4` → `@3e5f45b2...` `# v8.0.1` (in `action.yml`)
  * `nick-fields/assert-action@v2` → `@0efd6166...` `# v4.0.1`

## why

* GitHub is deprecating the Node 20 runtime; affected workflows emit a deprecation warning and
  are already being force-migrated to Node 24
* SHA pinning with a verified tag comment makes the upgrade deliberate and supply-chain-safe,
  matching the org's direction in cloudposse/.github#261
* Every pinned SHA was verified against its upstream tag

Supersedes #46
Supersedes #44
Supersedes #38

## references

* https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## still on Node 20

* `cloudposse/github-action-matrix-outputs-write@v1` — no Node 24 release exists yet
* `dcarbone/install-jq-action@v2.1.0` (in `action.yml`) — not covered by this upgrade matrix; Renovate #47 proposes v4 separately
